### PR TITLE
Recover sender address from signature, not send it

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,3 +29,20 @@ The server folder contains a node.js server using [express](https://expressjs.co
 The application should connect to the default server port (3042) automatically! 
 
 _Hint_ - Use [nodemon](https://www.npmjs.com/package/nodemon) instead of `node` to automatically restart the server on any changes.
+
+
+### Note
+```
+toHex(keccak256(Buffer.from(msg)))
+```
+This method returns exact same hash (and utf8 array, assuming the removal of `toHex` wrapper) as the following one
+```
+const hashMessage = (msg) => {
+  const splitMessage = utf8ToBytes(msg)
+  let hashedMessage = keccak256(splitMessage)
+
+  hashedMessage = toHex(hashedMessage)
+
+  return hashedMessage
+}
+```


### PR DESCRIPTION
Refactored the send action to derive the address from the signature instead of having the client-side send that. It can be maliciously to use the sender address from the client-side